### PR TITLE
Set up Rust workspace with crate structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,6 +3198,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "publisher-wasm"
+version = "0.1.0"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/export-pdf",
     "crates/export-epub",
     "crates/collab",
+    "crates/wasm",
     "backend",
     "apps/cli",
     "apps/desktop/src-tauri",

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -2,3 +2,13 @@ pub fn init() {
     publisher_core::init();
     println!("Publisher Collab Initialized");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collab_init() {
+        init();
+    }
+}

--- a/crates/color/src/lib.rs
+++ b/crates/color/src/lib.rs
@@ -2,3 +2,13 @@ pub fn init() {
     publisher_core::init();
     println!("Publisher Color Initialized");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_color_init() {
+        init();
+    }
+}

--- a/crates/export-epub/src/lib.rs
+++ b/crates/export-epub/src/lib.rs
@@ -2,3 +2,13 @@ pub fn init() {
     publisher_core::init();
     println!("Publisher Export EPUB Initialized");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_export_epub_init() {
+        init();
+    }
+}

--- a/crates/export-pdf/src/lib.rs
+++ b/crates/export-pdf/src/lib.rs
@@ -2,3 +2,13 @@ pub fn init() {
     publisher_core::init();
     println!("Publisher Export PDF Initialized");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_export_pdf_init() {
+        init();
+    }
+}

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -34,3 +34,13 @@ pub fn init() {
     publisher_core::init();
     println!("Publisher Renderer Initialized with Vello support");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_renderer_init() {
+        init();
+    }
+}

--- a/crates/typography/src/lib.rs
+++ b/crates/typography/src/lib.rs
@@ -2,3 +2,13 @@ pub fn init() {
     publisher_core::init();
     println!("Publisher Typography Initialized");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_typography_init() {
+        init();
+    }
+}

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "publisher-wasm"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,0 +1,14 @@
+/// WASM bindings for browser build
+pub fn init() {
+    println!("Publisher WASM Initialized");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wasm_init() {
+        init();
+    }
+}


### PR DESCRIPTION
## Summary

Set up the Rust workspace with all planned crates and unit tests:
- Created `crates/wasm` with lib.rs and passing unit test
- Added unit tests to `typography`, `color`, `renderer`, `export-pdf`, `export-epub`, and `collab` crates
- Updated workspace Cargo.toml to include all crates

## Test plan

- [x] `cargo build` succeeds with all crates (tested locally)
- [x] Each crate has a `lib.rs` with module stub and one passing unit test (all tested)
- [x] CI configured to run `cargo test` on push (verified in .github/workflows/ci.yml)

All tests pass:
- publisher-core: 9 tests
- publisher-typography: 1 test
- publisher-color: 1 test
- publisher-renderer: 1 test
- publisher-export-pdf: 1 test
- publisher-export-epub: 1 test
- publisher-collab: 1 test
- publisher-wasm: 1 test

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4tvayBsdee8XNNjZJ2j88)_