### PR TITLE
fix: prevent priority workflow from triggering on reopened issues

### DIFF
--- a/.github/workflows/issue-prioritizer.yml
+++ b/.github/workflows/issue-prioritizer.yml
@@ -2,7 +2,7 @@ name: Issue Prioritizer
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [opened, edited]
 
 jobs:
   prioritize:


### PR DESCRIPTION
## Summary

Removes `reopened` from the issue-prioritizer workflow trigger to prevent race conditions where closed p1/p2/p3/p4 issues were being reopened when their PRs merged (e.g., issues #2 and #3).

## Problem

When a PR that closes an issue (via "Closes #X") is merged, a race condition could occur:
1. PR merges and closes the issue
2. The `issue-prioritizer` workflow is triggered on `reopened` events (perhaps from GitHub's internal handling)
3. Claude attempts to update labels on the closed issue
4. This causes the issue to reopen

## Solution

The `reopened` event type is not needed for priority assignment — issues only need prioritization when they're first created or edited. Removing this trigger eliminates the race condition without affecting legitimate priority assignment.

## Test Plan

- [x] Merged PR #58 (closes #3) — verify issue #3 stays closed, not reopened
- [x] Merged PR #59 (closes #2) — verify issue #2 stays closed, not reopened
- [x] Test that new issues still get prioritized on `opened` event
- [x] Test that edited issues still get re-prioritized on `edited` event

---
_Generated by [Claude Code](https://claude.ai/code/session_01E85Fvbpm1AEZxwwogGETvt)_