### PR TITLE
fix: configure git for nightly release tag operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libgdk-pixbuf2.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libcairo-dev libpango-1.0-0 libpangocairo-1.0-0 libxcb-dri3-dev libxdamage-dev
+        env:
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -66,6 +68,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libgdk-pixbuf2.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libcairo-dev libpango-1.0-0 libpangocairo-1.0-0 libxcb-dri3-dev libxdamage-dev
+        env:
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -84,6 +88,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
         with:
           args: "--target ${{ matrix.target }}"
           projectPath: "apps/desktop"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libgdk-pixbuf2.0-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libgdk-pixbuf2.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libcairo-dev libpango-1.0-0 libpangocairo-1.0-0 libxcb-dri3-dev libxdamage-dev
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -65,7 +65,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libgdk-pixbuf2.0-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libgdk-pixbuf2.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libcairo-dev libpango-1.0-0 libpangocairo-1.0-0 libxcb-dri3-dev libxdamage-dev
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Problem

The `release-nightly` job in CI attempts to create and push git tags without configuring git user identity. This causes the following error:

```
fatal: not a valid identity
```

Without git user configuration, `git push origin "refs/tags/$TAG"` fails, preventing the nightly release from being created/updated.

## Solution

Configure git with `user.email` and `user.name` before tag operations.

## Impact

This is required for PR #62 (GTK dependencies) to work correctly. Once PR #62 merges and triggers the CI, this fix ensures the release-nightly job completes successfully and updates the nightly release with current build artifacts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E85Fvbpm1AEZxwwogGETvt)_