### PR TITLE
fix: set PKG_CONFIG_PATH only on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,14 @@ jobs:
       - name: Install Svelte dependencies
         run: npm install --prefix apps/web
 
+      - name: Set PKG_CONFIG_PATH (Linux only)
+        if: runner.os == 'Linux'
+        run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig" >> $GITHUB_ENV
+
       - name: Build Desktop App Bundles
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
         with:
           args: "--target ${{ matrix.target }}"
           projectPath: "apps/desktop"


### PR DESCRIPTION
## Problem

PKG_CONFIG_PATH is a Linux-specific environment variable. In PR #63, I set it globally for all platforms in the Tauri build step. This causes build failures on macOS and Windows, which don't use pkg-config.

## Solution

Use a conditional step to only set PKG_CONFIG_PATH on Linux runners. Use `$GITHUB_ENV` to pass it to the Tauri build step, which will inherit it.

## Impact

This should fix the build failures on macOS and Windows that were preventing the Nightly release from being updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E85Fvbpm1AEZxwwogGETvt)_