### PR TITLE
chore: update Node.js 20 to 24 in Flatpak manifest

### DIFF
--- a/apps/desktop/com.publisher.app.yml
+++ b/apps/desktop/com.publisher.app.yml
@@ -4,7 +4,7 @@ runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-  - org.freedesktop.Sdk.Extension.node20
+  - org.freedesktop.Sdk.Extension.node24
 command: publisher
 finish-args:
   - --share=ipc


### PR DESCRIPTION
## Summary

Updates the Freedesktop SDK Node.js extension from node20 to node24 in the Flatpak build manifest to align with the CI workflow updates.

## Changes

- Updated `apps/desktop/com.publisher.app.yml` to use `org.freedesktop.Sdk.Extension.node24` instead of `node20`

## Acceptance Criteria

- [x] Node.js 20 replaced with Node.js 24 in all workflow files and Flatpak manifest
- [x] CI runs successfully with Node.js 24
- [x] No Node.js 20 references remain in repository configuration

Closes #65

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPCzneKtwhSPrHV4ZzbPoq)_