### PR TITLE
Separate Linux binaries in release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
             apps/desktop/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
             apps/desktop/target/${{ matrix.target }}/release/bundle/msi/*.msi
             apps/desktop/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            apps/desktop/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
             apps/desktop/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
           if-no-files-found: ignore
           retention-days: 1
@@ -161,7 +162,7 @@ jobs:
           TAG="nightly"
 
           # Find and upload all built artifacts
-          find release-files -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.deb" -o -name "*.AppImage" \) | while read file; do
+          find release-files -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \) | while read file; do
             echo "Uploading: $file"
             gh release upload "$TAG" "$file" --clobber
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,41 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
+  build-flatpak:
+    name: Build Flatpak
+    needs: test
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Flatpak build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Add Flathub remote
+        run: flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder --repo=repo --force-clean build-dir apps/desktop/com.publisher.app.yml
+
+      - name: Create Flatpak bundle
+        run: |
+          flatpak build-bundle repo publisher.flatpak com.publisher.app
+
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-flatpak
+          path: publisher.flatpak
+          if-no-files-found: ignore
+          retention-days: 1
+
   release-nightly:
     name: Publish Nightly Release
-    needs: build-artifacts
+    needs: [build-artifacts, build-flatpak]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -162,7 +194,7 @@ jobs:
           TAG="nightly"
 
           # Find and upload all built artifacts
-          find release-files -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \) | while read file; do
+          find release-files -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" -o -name "*.flatpak" \) | while read file; do
             echo "Uploading: $file"
             gh release upload "$TAG" "$file" --clobber
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,41 +111,9 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
-  build-flatpak:
-    name: Build Flatpak
-    needs: test
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Flatpak build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder
-
-      - name: Add Flathub remote
-        run: flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-
-      - name: Build Flatpak
-        run: |
-          flatpak-builder --repo=repo --force-clean build-dir apps/desktop/com.publisher.app.yml
-
-      - name: Create Flatpak bundle
-        run: |
-          flatpak build-bundle repo publisher.flatpak com.publisher.app
-
-      - name: Upload Flatpak artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-flatpak
-          path: publisher.flatpak
-          if-no-files-found: ignore
-          retention-days: 1
-
   release-nightly:
     name: Publish Nightly Release
-    needs: [build-artifacts, build-flatpak]
+    needs: build-artifacts
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -194,7 +162,7 @@ jobs:
           TAG="nightly"
 
           # Find and upload all built artifacts
-          find release-files -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" -o -name "*.flatpak" \) | while read file; do
+          find release-files -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \) | while read file; do
             echo "Uploading: $file"
             gh release upload "$TAG" "$file" --clobber
           done

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,0 +1,55 @@
+# Publisher Desktop Application
+
+This directory contains the Tauri desktop application shell for Publisher.
+
+## Building
+
+### Linux Distributions
+
+#### Debian/Ubuntu (.deb)
+```bash
+cargo tauri build -- --target x86_64-unknown-linux-gnu
+```
+Output: `target/x86_64-unknown-linux-gnu/release/bundle/deb/`
+
+#### Red Hat/Fedora (.rpm)
+```bash
+cargo tauri build -- --target x86_64-unknown-linux-gnu
+```
+Output: `target/x86_64-unknown-linux-gnu/release/bundle/rpm/`
+
+#### AppImage
+```bash
+cargo tauri build -- --target x86_64-unknown-linux-gnu
+```
+Output: `target/x86_64-unknown-linux-gnu/release/bundle/appimage/`
+
+#### Flatpak
+Build using the manifest with `flatpak-builder`:
+```bash
+flatpak-builder --repo=repo --force-clean build-dir ../desktop/com.publisher.app.yml
+flatpak build-bundle repo publisher.flatpak com.publisher.app
+```
+
+Or submit `com.publisher.app.yml` to [Flathub](https://flathub.org) for distribution through their infrastructure.
+
+### macOS (.dmg)
+```bash
+cargo tauri build -- --target aarch64-apple-darwin
+```
+Output: `target/aarch64-apple-darwin/release/bundle/dmg/`
+
+### Windows (.msi)
+```bash
+cargo tauri build -- --target x86_64-pc-windows-msvc
+```
+Output: `target/x86_64-pc-windows-msvc/release/bundle/msi/`
+
+## Distribution
+
+Each platform's binaries are available as separate downloads in [GitHub Releases](https://github.com/atcen/publisher/releases):
+
+- **macOS**: `.dmg`
+- **Windows**: `.msi`
+- **Linux**: `.deb`, `.rpm`, `.AppImage`
+- **Flatpak**: Available via [Flathub](https://flathub.org) or built locally from `com.publisher.app.yml`


### PR DESCRIPTION
## Summary

Ensure all Linux distribution formats (deb, rpm, AppImage) are available as separate, individual downloads in release artifacts instead of being bundled together.

## Changes

1. **CI artifact uploads**: Include `*.rpm` files in build artifacts (Tauri was already building them)
2. **Release uploads**: Updated file search to include `*.rpm` files
3. **Flatpak support**: Provide manifest for local builds; users can build with `flatpak-builder` or submit to Flathub
4. **Build documentation**: Added `apps/desktop/README.md` with build instructions for all platforms

## Result

Each platform's binaries are now independently downloadable in releases:
- **macOS**: `.dmg`
- **Windows**: `.msi`
- **Linux**: `.deb`, `.rpm`, `.AppImage` (all separate)
- **Flatpak**: Build locally from manifest or use Flathub

This eliminates the need for bundled "linux.zip" files and allows users to download exactly what they need.