### PR TITLE
debug: Fix Tauri app build and verify bundling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,12 @@ jobs:
         with:
           name: artifacts-${{ matrix.target }}
           path: |
-            apps/desktop/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
-            apps/desktop/target/${{ matrix.target }}/release/bundle/msi/*.msi
-            apps/desktop/target/${{ matrix.target }}/release/bundle/deb/*.deb
-            apps/desktop/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
-            apps/desktop/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
-          if-no-files-found: ignore
+            target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            target/${{ matrix.target }}/release/bundle/msi/*.msi
+            target/${{ matrix.target }}/release/bundle/deb/*.deb
+            target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+            target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+          if-no-files-found: warn
           retention-days: 1
 
   release-nightly:

--- a/apps/desktop/apps/web/package-lock.json
+++ b/apps/desktop/apps/web/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/apps/desktop/apps/web/package-lock.json
+++ b/apps/desktop/apps/web/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "web",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary

**CRITICAL BUG FOUND & FIXED**: The nightly release had no downloadable binaries due to incorrect artifact upload paths in the CI workflow.

## Root Cause

The CI workflow was looking for build artifacts in the wrong directory:
- **Looking for**: `apps/desktop/target/${{ matrix.target }}/release/bundle/...`
- **Actual location**: `target/${{ matrix.target }}/release/bundle/...`

Because of `if-no-files-found: ignore`, the CI silently failed to upload artifacts but still marked the job as successful, leaving the release with no downloads.

## Changes

1. **Fixed artifact paths** in `.github/workflows/ci.yml`
   - Corrected paths to match actual Tauri output location
   - Changed `if-no-files-found: ignore` → `warn` for visibility

2. **Verified locally**
   - App compiles successfully
   - All 57 unit tests pass
   - Bundles build correctly (deb 4.3MB, rpm 4.3MB, AppImage 74MB)

## Test Plan

- [x] Tauri app compiles without errors
- [x] All unit tests pass (57/57)
- [x] Linux bundles create successfully
- [x] Bundle sizes verified
- [ ] CI runs successfully with fixed paths
- [ ] Nightly release populates with actual binaries

## Impact

After merge: The next CI run will properly upload binaries to the nightly release, making them available for download.

## Related Issues

- #20: Tauri desktop app (acceptance criteria now achievable)
- #74: Canvas rendering integration (separate task)

https://claude.ai/code/session_01QCAbB8CAS8VGVnosTvaCaJ