### PR TITLE
Fix CI artifact upload for cross-platform builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.target }}
-          path: |
-            target/${{ matrix.target }}/release/bundle/dmg/*.dmg
-            target/${{ matrix.target }}/release/bundle/msi/*.msi
-            target/${{ matrix.target }}/release/bundle/deb/*.deb
-            target/${{ matrix.target }}/release/bundle/rpm/*.rpm
-            target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+          path: target/${{ matrix.target }}/release/bundle
           if-no-files-found: warn
           retention-days: 1
 


### PR DESCRIPTION
## Fix

Simplify artifact upload to use generic bundle directory path instead of listing platform-specific bundle formats.

**Problem:** The CI workflow specifies separate paths for each bundle format (dmg, msi, deb, rpm, AppImage). When Tauri builds on Windows, only `.msi` files are produced, so the action fails with "no files found" warnings for dmg/deb/rpm/AppImage paths.

**Solution:** Upload the entire bundle directory. Tauri automatically outputs the correct format per platform, so this works universally without platform-specific conditionals.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAyBDX5YLKuRPqpGNHSNwK)_